### PR TITLE
Update v1 columns block to handle left images setup

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -182,6 +182,12 @@ hr.column-underline {
     order: unset;
   }
 
+  .columns-promo-text-wrapper.columns-promo-img-left {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+  }
+
   .columns.promo.underlined-text .columns-promo-picture-wrapper {
     display: flex;
     align-items: center;

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -68,8 +68,10 @@ export default function decorate(block) {
     const parent = block.querySelectorAll(':scope > div > div');
     const textParent = getAllElWithChildren(parent, 'picture', true)[0];
     const pictureParent = getAllElWithChildren(parent, 'picture')[0];
+    const imgLeft = parent[0].querySelector('picture');
     textParent.className = 'columns-promo-text-wrapper';
     if (pictureParent) pictureParent.className = 'columns-promo-picture-wrapper';
+    if (imgLeft) textParent.classList.add('columns-promo-img-left');
   }
 
   videoHandling(block);


### PR DESCRIPTION
# Fixed

item 15 is fixed in this update. columns block that has an image on the left side, will share the same space between columns as the other variant with the image on the right side

#

### Fix #15 

Test URLs:
- Before: https://main--vg-macktrucks-ca--hlxsites.hlx.page/trucks/md/
- After: https://15-mt-ca-consolidated-issues--vg-macktrucks-ca--hlxsites.hlx.page/trucks/md/
