### PR TITLE
638 Restore OneTrust cookie check

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,5 +1,5 @@
 // check if an active campaign is running or OneTrust needs scan the active scripts
-export const COOKIE_CHECK = true;
+export const COOKIE_CHECK = false;
 
 // ONE TRUST COOKIE CONSENT
 export const DATA_DOMAIN_SCRIPT = 'bbf7a698-6707-4c02-8cee-8cfa4d077625';


### PR DESCRIPTION
# Update

Restore the OneTrust cookie check after a successful backend script scan

#

Fix [638](https://github.com/hlxsites/vg-macktrucks-com/issues/638)

Test URLs:
- Before: https://main--vg-macktrucks-ca--hlxsites.hlx.page/
- After: https://638-enable-script-check--vg-macktrucks-ca--hlxsites.hlx.page/
